### PR TITLE
Add support for NUnit

### DIFF
--- a/UnitTestAnalyzers/UnitTestAnalyzers.Test/Design/TestNameMustIncludeMemberUnderTestFunctionalTests.cs
+++ b/UnitTestAnalyzers/UnitTestAnalyzers.Test/Design/TestNameMustIncludeMemberUnderTestFunctionalTests.cs
@@ -31,6 +31,15 @@
         }
 
         [Theory]
+        [ClassData(typeof(TestNameMustIncludeMemberUnderTestAnalyzerNUnitTestInvalidData))]
+        public async Task IncludeMemberUnderTestInTestName_NUnitTestCodeWithViolation_ExpectsDiagnostic(string testCode, string testMethodName, string testMethodNameMemberUnderTest, int violantioLine, int violationColumn, string settings)
+        {
+            this.settings = settings;
+            DiagnosticResult expected = this.CSharpDiagnostic().WithArguments(testMethodName, testMethodNameMemberUnderTest).WithLocation(violantioLine, violationColumn);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None, UnitTestFramework.NUnit).ConfigureAwait(false);
+        }
+
+        [Theory]
         [ClassData(typeof(TestNameMustIncludeMemberUnderTestAnalyzerMSTestValidData))]
         public async Task IncludeMemberUnderTestInTestName_MSTestCodeWithoutViolation_ExpectsNoDiagnostic(string testCode, string settings)
         {
@@ -44,6 +53,14 @@
         {
             this.settings = settings;
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None, UnitTestFramework.Xunit).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [ClassData(typeof(TestNameMustIncludeMemberUnderTestAnalyzerNUnitTestValidData))]
+        public async Task IncludeMemberUnderTestInTestName_NUnitTestCodeWithoutViolation_ExpectsNoDiagnostic(string testCode, string settings)
+        {
+            this.settings = settings;
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None, UnitTestFramework.NUnit).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/UnitTestAnalyzers/UnitTestAnalyzers.Test/Documentation/UseAAACommentsFunctionalTests.cs
+++ b/UnitTestAnalyzers/UnitTestAnalyzers.Test/Documentation/UseAAACommentsFunctionalTests.cs
@@ -52,6 +52,25 @@
         }
 
         [Theory]
+        [ClassData(typeof(UseAAACommentsAnalyzerNUnitTestInvalidData))]
+        public async Task UseAAAComments_NUnitTestCodeWithViolation_ExpectsDiagnostic(string testCode, string testMethodName, int violantioLine, int violationColumn, string settings, bool hasValidAAAComments, bool firstLineIsArrangeComment)
+        {
+            this.settings = settings;
+            var expectedDiagnostics = new List<DiagnosticResult>();
+            if (!hasValidAAAComments)
+            {
+                expectedDiagnostics.Add(this.CSharpDiagnostic(UseAAACommentsAnalyzer.AAACommentsDiagnosticId).WithArguments(testMethodName).WithLocation(violantioLine, violationColumn));
+            }
+
+            if (!firstLineIsArrangeComment)
+            {
+                expectedDiagnostics.Add(this.CSharpDiagnostic(UseAAACommentsAnalyzer.ArrangeCommentFirstLineDiagnosticId).WithArguments(testMethodName).WithLocation(violantioLine, violationColumn));
+            }
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostics.ToArray(), CancellationToken.None, UnitTestFramework.NUnit).ConfigureAwait(false);
+        }
+
+        [Theory]
         [ClassData(typeof(UseAAACommentsAnalyzerMSTestValidData))]
         public async Task UseAAAComments_MSTestCodeWithoutViolation_ExpectsNoDiagnostic(string testCode, string settings)
         {
@@ -65,6 +84,14 @@
         {
             this.settings = settings;
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None, UnitTestFramework.Xunit).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [ClassData(typeof(UseAAACommentsAnalyzerNUnitTestValidData))]
+        public async Task UseAAAComments_NUnitTestCodeWithoutViolation_ExpectsNoDiagnostic(string testCode, string settings)
+        {
+            this.settings = settings;
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None, UnitTestFramework.NUnit).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/UnitTestAnalyzers/UnitTestAnalyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/UnitTestAnalyzers/UnitTestAnalyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
@@ -1,4 +1,6 @@
-﻿namespace TestHelper
+﻿using NUnit.Framework;
+
+namespace TestHelper
 {
     using System;
     using System.Collections.Generic;
@@ -37,6 +39,7 @@
         private static readonly MetadataReference ThisProjectReference = MetadataReference.CreateFromFile(typeof(TestSettingsData).Assembly.Location);
         private static readonly MetadataReference MsTestReference = MetadataReference.CreateFromFile(typeof(TestClassAttribute).Assembly.Location);
         private static readonly MetadataReference XunitReference = MetadataReference.CreateFromFile(typeof(TheoryAttribute).Assembly.Location);
+        private static readonly MetadataReference NUnitReference = MetadataReference.CreateFromFile(typeof(TestCaseAttribute).Assembly.Location);
         private static readonly string ProgramFilesX86 = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
         private static readonly MetadataReference PortableCorlibReference = MetadataReference.CreateFromFile(Path.Combine(ProgramFilesX86, @"Reference Assemblies\Microsoft\Framework\.NETPortable\v4.5\Profile\Profile7\System.Runtime.dll"));
 
@@ -170,7 +173,10 @@
                     unitTestFrameworkReference = XunitReference;
                     corlibReference = PortableCorlibReference;
                     break;
-
+                case UnitTestFramework.NUnit:
+                    unitTestFrameworkReference = NUnitReference;
+                    corlibReference = CorlibReference;
+                    break;
                 default:
                     throw new ArgumentException("The provided value is not supported", nameof(framework));
             }

--- a/UnitTestAnalyzers/UnitTestAnalyzers.Test/Naming/UseCorrectTestNameFormatFunctionalTests.cs
+++ b/UnitTestAnalyzers/UnitTestAnalyzers.Test/Naming/UseCorrectTestNameFormatFunctionalTests.cs
@@ -48,6 +48,24 @@
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None, UnitTestFramework.Xunit).ConfigureAwait(false);
         }
 
+        [Theory]
+        [ClassData(typeof(UseCorrectTestNameFormatNUnitTestInvalidData))]
+        public async Task UseCorrectTestNameFormat_NUnitTestCodeWithViolation_ExpectsDiagnostic(string testCode, string testMethodName, int violantioLine, int violationColumn, string settings, string testMethodFormat, string[] testMethodNameExamples)
+        {
+            this.settings = settings;
+            string testMethodNameExamplesArgument = string.Join(", ", testMethodNameExamples);
+            DiagnosticResult expected = this.CSharpDiagnostic().WithArguments(testMethodName, testMethodFormat, testMethodNameExamplesArgument).WithLocation(violantioLine, violationColumn);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None, UnitTestFramework.NUnit).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [ClassData(typeof(UseCorrectTestNameFormatNUnitTestValidData))]
+        public async Task UseCorrectTestNameFormat_UsingNUnitTestCodeWithoutViolation_ExpectsNoDiagnostic(string testCode, string settings)
+        {
+            this.settings = settings;
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None, UnitTestFramework.NUnit).ConfigureAwait(false);
+        }
+
         /// <summary>
         /// Get the CSharp analyzer being tested.
         /// </summary>

--- a/UnitTestAnalyzers/UnitTestAnalyzers.Test/Naming/UseUnitTestsSuffixFunctionalTests.cs
+++ b/UnitTestAnalyzers/UnitTestAnalyzers.Test/Naming/UseUnitTestsSuffixFunctionalTests.cs
@@ -46,6 +46,23 @@
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None, UnitTestFramework.Xunit).ConfigureAwait(false);
         }
 
+        [Theory]
+        [ClassData(typeof(UseUnitTestsSuffixNUnitTestValidData))]
+        public async Task UseUnitTestsSuffix_NUnitTestCodeWithoutViolation_ExpectsNoDiagnostic(string testCode, string settings)
+        {
+            this.settings = settings;
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None, UnitTestFramework.NUnit).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [ClassData(typeof(UseUnitTestsSuffixNUnitTestInvalidData))]
+        public async Task UseUnitTestsSuffix_NUnitTestCodeWithViolation_ExpectsDiagnostic(string testCode, string testClassName, int violantionLine, int violationColumn, string settings)
+        {
+            this.settings = settings;
+            DiagnosticResult expected = this.CSharpDiagnostic().WithArguments(testClassName).WithLocation(violantionLine, violationColumn);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None, UnitTestFramework.NUnit).ConfigureAwait(false);
+        }
+
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {
             return new UseUnitTestsSuffixAnalyzer();

--- a/UnitTestAnalyzers/UnitTestAnalyzers.Test/TestData/TestNameMustIncludeMemberUnderTestAnalyzerNUnitTestInvalidData.cs
+++ b/UnitTestAnalyzers/UnitTestAnalyzers.Test/TestData/TestNameMustIncludeMemberUnderTestAnalyzerNUnitTestInvalidData.cs
@@ -1,0 +1,160 @@
+﻿namespace UnitTestAnalyzers.Test.TestData
+{
+    using System.Collections;
+    using System.Collections.Generic;
+
+    internal class TestNameMustIncludeMemberUnderTestAnalyzerNUnitTestInvalidData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            // A test method targeting a constructor does not have its first part matching the name of the constructor under test.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class RegexUnitTests
+{
+[Test]
+public void TestCtor_UsingNullString_ThrowsArgumentNullException() 
+{
+    Regex r = new Regex(null);
+}
+}",
+"TestCtor_UsingNullString_ThrowsArgumentNullException", // Diagnostic message paramater
+"TestCtor", // Diagnostic message parameter
+5,  // Violation line
+13,  // Violation column.
+TestSettingsData.NUnitSettings
+            };
+
+            // A test method targeting a property does not have its first part matching the name of the property under test.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class RegexUnitTests
+{
+[Test]
+public void TestProperty_WhenOptionsIsNotProvided_ExpectsRetrievedOptionsEmpty() 
+{
+    Regex r = new Regex(""regex"");
+    var options = r.Options;
+}
+}",
+"TestProperty_WhenOptionsIsNotProvided_ExpectsRetrievedOptionsEmpty",
+"TestProperty",
+5,
+13,
+TestSettingsData.NUnitSettings
+            };
+
+            // A test method targeting a method does not have its first part matching the name of the method under test.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class RegexUnitTests
+{
+[Test]
+public void TestMethod_UsingNonMatchingString_ExpectsFalse() 
+{
+    Regex r = new Regex(""regex"");
+    var result = r.IsMatch(""Foo"");
+}
+}",
+"TestMethod_UsingNonMatchingString_ExpectsFalse",
+"TestMethod",
+5,
+13,
+TestSettingsData.NUnitSettings
+            };
+
+            // A test method targeting a method does not have its first part matching the name of the method under test.
+            // Instead that part matches the name of a variable within the test body.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class RegexUnitTests
+{
+[Test]
+public void result_UsingNonMatchingString_ExpectsFalse() 
+{
+    Regex r = new Regex(""regex"");
+    var result = r.IsMatch(""Foo"");
+}
+}",
+"result_UsingNonMatchingString_ExpectsFalse",
+"result",
+5,
+13,
+TestSettingsData.NUnitSettings
+            };
+
+            // A test method targeting a method does not have its first part matching the name of the method under test.
+            // Instead that part matches the name of a parameter within the test body.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class RegexUnitTests
+{
+[Test]
+public void Foo_UsingNonMatchingString_ExpectsFalse() 
+{
+    Regex r = new Regex(""regex"");
+    var result = r.IsMatch(""Foo"");
+}
+}",
+"Foo_UsingNonMatchingString_ExpectsFalse",
+"Foo",
+5,
+13,
+TestSettingsData.NUnitSettings
+            };
+
+            // A test method targeting a method does not have its first part matching the name of the method under test.
+            // Instead that part matches a comment withing the method body.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class RegexUnitTests
+{
+[Test]
+public void Init_UsingNonMatchingString_ExpectsFalse() 
+{
+    // Init.
+    Regex r = new Regex(""regex"");
+    var result = r.IsMatch(""Foo"");
+}
+}",
+"Init_UsingNonMatchingString_ExpectsFalse",
+"Init",
+5,
+13,
+TestSettingsData.NUnitSettings
+            };
+
+            // A test method name not have its member under test part matching the name of the method under test.
+            // The analyzer settings provides a new regex that defines a group named 'memberUnderTestName'.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class RegexUnitTests
+{
+[Test]
+public void TestFoo_Method() 
+{
+    Regex r = new Regex(""regex"");
+    var result = r.IsMatch(""Foo"");
+}
+}",
+"TestFoo_Method",
+"Method",
+5,
+13,
+TestSettingsData.NUnitTestSettingsMemberUnderTestRegexFormat
+            };
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+    }
+}

--- a/UnitTestAnalyzers/UnitTestAnalyzers.Test/TestData/TestNameMustIncludeMemberUnderTestAnalyzerNUnitTestValidData.cs
+++ b/UnitTestAnalyzers/UnitTestAnalyzers.Test/TestData/TestNameMustIncludeMemberUnderTestAnalyzerNUnitTestValidData.cs
@@ -1,0 +1,154 @@
+﻿namespace UnitTestAnalyzers.Test.TestData
+{
+    using System.Collections;
+    using System.Collections.Generic;
+
+    internal class TestNameMustIncludeMemberUnderTestAnalyzerNUnitTestValidData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            // The test method name does not match the Regex pattern in the member under test group.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class RegexUnitTests
+{
+[Test]
+public void TestCtor!_UsingNullString_ThrowsArgumentNullException() 
+{
+    Regex r = new Regex(null);
+}
+}",
+TestSettingsData.NUnitSettings
+            };
+
+            // The test method with empty body.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class RegexUnitTests
+{
+[Test]
+public void TestMethod_UsingNullString_ThrowsArgumentNullException() 
+{
+}
+}",
+TestSettingsData.NUnitSettings
+            };
+
+            // The test method with body containing comments only.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class RegexUnitTests
+{
+[Test]
+public void TestMethod_UsingNullString_ThrowsArgumentNullException() 
+{
+// Comment.
+}
+}",
+TestSettingsData.NUnitSettings
+            };
+
+            // The test method with body containing a variable declaration only.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class RegexUnitTests
+{
+[Test]
+public void TestMethod_UsingNullString_ThrowsArgumentNullException() 
+{
+    string str = ""foo""
+}
+}",
+TestSettingsData.NUnitSettings
+            };
+
+            // The test method name does not match the Regex pattern in another part of the name.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class RegexUnitTests
+{
+[Test]
+public void TestCtor_NullString_ThrowsArgumentNullException() 
+{
+    Regex r = new Regex(null);
+}
+}",
+TestSettingsData.NUnitSettings
+            };
+
+            // A test method targeting a constructor has its first part matching the name of the constructor under test.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class RegexUnitTests
+{
+[Test]
+public void Regex_UsingNullString_ThrowsArgumentNullException() 
+{
+    Regex r = new Regex(null);
+}
+}",
+TestSettingsData.NUnitSettings
+            };
+
+            // A test method targeting a property has its first part matching the name of the property under test.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class RegexUnitTests
+{
+[Test]
+public void Options_WhenOptionsIsNotProvided_ExpectsRetrievedOptionsEmpty() 
+{
+    Regex r = new Regex(""regex"");
+    var options = r.Options;
+}
+}",
+TestSettingsData.NUnitSettings
+            };
+
+            // A test method targeting a method has its first part matching the name of the method under test.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class RegexUnitTests
+{
+[Test]
+public void IsMatch_UsingNonMatchingString_ExpectsFalse() 
+{
+    Regex r = new Regex(""regex"");
+    var result = r.IsMatch(""Foo"");
+}
+}",
+TestSettingsData.NoSettings
+            };
+
+            // A test method name has its member under test part matching the name of the method under test.
+            // The analyzer settings provides a new regex that defines a group named 'memberUnderTestName'.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class RegexUnitTests
+{
+[Test]
+public void TestFoo_IsMatch() 
+{
+    Regex r = new Regex(""regex"");
+    var result = r.IsMatch(""Foo"");
+}
+}",
+TestSettingsData.NUnitTestSettingsMemberUnderTestRegexFormat
+            };
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+    }
+}

--- a/UnitTestAnalyzers/UnitTestAnalyzers.Test/TestData/TestSettingsData.cs
+++ b/UnitTestAnalyzers/UnitTestAnalyzers.Test/TestData/TestSettingsData.cs
@@ -10,6 +10,12 @@
                 }
               }";
 
+        internal const string NUnitSettings = @"{
+                ""settings"" : {
+                ""unitTestFramework"" : ""NUnit""
+                }
+              }";
+
         internal const string InvalidSettings = @"
                 ""settings"" : {
                 ""unitTestFramework"" , ""MSTest""
@@ -50,10 +56,29 @@
                  }}
               }}";
 
+        internal static string NUnitTestSettingsSimpleRegex =>
+            $@"{{
+                ""settings"" : {{
+                ""unitTestFramework"" : ""NUnit"",
+                ""testMethodNameFormat"" : {TestMethodNameSimpleFormatJson},
+                ""testMethodNameFormatRegex"" : {{""Pattern"" : {TestMethodNameFormatSimpleRegex} }},
+                ""testMethodNameFormatExamples"" : {JsonConvert.SerializeObject(TestMethodNameFormatSimpleRegexExamples)}
+                 }}
+              }}";
+
         internal static string XunitTestSettingsSimpleRegexNoFormat =>
                     $@"{{
                 ""settings"" : {{
                 ""unitTestFramework"" : ""Xunit"",
+                ""testMethodNameFormatRegex"" : {{""Pattern"" : {TestMethodNameFormatSimpleRegex} }},
+                ""testMethodNameFormatExamples"" : {JsonConvert.SerializeObject(TestMethodNameFormatSimpleRegexExamples)}
+                 }}
+              }}";
+
+       internal static string NUnitTestSettingsSimpleRegexNoFormat =>
+                    $@"{{
+                ""settings"" : {{
+                ""unitTestFramework"" : ""NUnit"",
                 ""testMethodNameFormatRegex"" : {{""Pattern"" : {TestMethodNameFormatSimpleRegex} }},
                 ""testMethodNameFormatExamples"" : {JsonConvert.SerializeObject(TestMethodNameFormatSimpleRegexExamples)}
                  }}
@@ -81,6 +106,14 @@
                     $@"{{
                 ""settings"" : {{
                 ""unitTestFramework"" : ""Xunit"",
+                ""testMethodNameFormatRegex"" : {{""Pattern"" : {TestMethodNameMemberUnderTestRegex} }}
+                 }}
+              }}";
+
+        internal static string NUnitTestSettingsMemberUnderTestRegexFormat =>
+                    $@"{{
+                ""settings"" : {{
+                ""unitTestFramework"" : ""NUnit"",
                 ""testMethodNameFormatRegex"" : {{""Pattern"" : {TestMethodNameMemberUnderTestRegex} }}
                  }}
               }}";

--- a/UnitTestAnalyzers/UnitTestAnalyzers.Test/TestData/UseAAACommentsAnalyzerNUnitTestInvalidData.cs
+++ b/UnitTestAnalyzers/UnitTestAnalyzers.Test/TestData/UseAAACommentsAnalyzerNUnitTestInvalidData.cs
@@ -1,0 +1,420 @@
+﻿namespace UnitTestAnalyzers.Test.TestData
+{
+    using System.Collections;
+    using System.Collections.Generic;
+
+    internal class UseAAACommentsAnalyzerNUnitTestInvalidData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            // A test method does not include any of the ArrangeActAssert  comments.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class RegexUnitTests
+{
+[Test]
+public void Regex_UsingNullString_ThrowsArgumentNullException() 
+{
+    Regex r = new Regex(null);
+}
+}",
+"Regex_UsingNullString_ThrowsArgumentNullException", // Diagnostic message paramater
+5,  // Violation line
+13,  // Violation column.
+TestSettingsData.NUnitSettings,
+false,
+false
+            };
+
+            // A test method has only the // Arrange. comment.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class RegexUnitTests
+{
+[Test]
+public void Regex_UsingNullString_ThrowsArgumentNullException() 
+{
+    // Arrange.
+    string str = null;
+
+    Regex r = new Regex(str);
+}
+}",
+"Regex_UsingNullString_ThrowsArgumentNullException",
+5,
+13,
+TestSettingsData.NUnitSettings,
+false,
+true
+            };
+
+            // A test method has only the // Act. comment.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class RegexUnitTests
+{
+[Test]
+public void Regex_UsingNullString_ThrowsArgumentNullException() 
+{
+    string str = null;
+
+    // Act.
+    Regex r = new Regex(str);
+}
+}",
+"Regex_UsingNullString_ThrowsArgumentNullException",
+5,
+13,
+TestSettingsData.NUnitSettings,
+false,
+false
+            };
+
+            // A test method has only the // Assert. comment.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class RegexUnitTests
+{
+[Test]
+public void Regex_UsingNullString_ThrowsArgumentNullException() 
+{
+    string str = null;
+
+    Regex r = new Regex(str);
+ 
+    // Assert.x
+}
+}",
+"Regex_UsingNullString_ThrowsArgumentNullException",
+5,
+13,
+TestSettingsData.NUnitSettings,
+false,
+false
+            };
+
+            // A test method does not have the // Arrange. comment.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class RegexUnitTests
+{
+[Test]
+public void Regex_UsingNullString_ThrowsArgumentNullException() 
+{
+    string str = null;
+
+    // Act.
+    Regex r = new Regex(str);
+
+    // Assert.
+}
+}",
+"Regex_UsingNullString_ThrowsArgumentNullException",
+5,
+13,
+TestSettingsData.NUnitSettings,
+false,
+false
+            };
+
+            // A test method does not have the // Act. comment.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class RegexUnitTests
+{
+[Test]
+public void Regex_UsingNullString_ThrowsArgumentNullException() 
+{
+    // Arrange.
+    string str = null;
+
+    Regex r = new Regex(null);
+
+   // Assert.
+}
+}",
+"Regex_UsingNullString_ThrowsArgumentNullException",
+5,
+13,
+TestSettingsData.NUnitSettings,
+false,
+true
+            };
+
+            // A test method does not include the // Assert. comment.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class RegexUnitTests
+{
+[Test]
+public void Regex_UsingNullString_ThrowsArgumentNullException() 
+{
+    // Arrange.
+    string str = null;
+
+   // Act.
+    Regex r = new Regex(null);
+}
+}",
+"Regex_UsingNullString_ThrowsArgumentNullException",
+5,
+13,
+TestSettingsData.NUnitSettings,
+false,
+true
+            };
+
+            // A test method has multiple // Arrange. comments
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class RegexUnitTests
+{
+[Test]
+public void Regex_UsingNullString_ThrowsArgumentNullException() 
+{
+    // Arrange.
+    string str = null;
+
+    // Arrange.
+
+    // Act.
+    Regex r = new Regex(null);
+
+   // Assert.
+}
+}",
+"Regex_UsingNullString_ThrowsArgumentNullException",
+5,
+13,
+TestSettingsData.NUnitSettings,
+false,
+true
+            };
+
+            // A test method has multiple // Act. comments
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class RegexUnitTests
+{
+[Test]
+public void Regex_UsingNullString_ThrowsArgumentNullException() 
+{
+    // Arrange.
+    string str = null;
+
+    // Act.
+    Regex r = new Regex(null);
+
+   // Act.
+   // Assert.
+}
+}",
+"Regex_UsingNullString_ThrowsArgumentNullException",
+5,
+13,
+TestSettingsData.NUnitSettings,
+false,
+true
+            };
+
+            // A test method has multiple // Assert. comments
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class RegexUnitTests
+{
+[Test]
+public void Regex_UsingNullString_ThrowsArgumentNullException() 
+{
+    // Arrange.
+    string str = null;
+
+    // Act.
+    Regex r = new Regex(null);
+
+   // Assert.
+
+   // Assert.
+}
+}",
+"Regex_UsingNullString_ThrowsArgumentNullException",
+5,
+13,
+TestSettingsData.NUnitSettings,
+false,
+true
+            };
+
+            // A test method has the ArrangeActAssert comments in the wrong order.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class RegexUnitTests
+{
+[Test]
+public void Regex_UsingNullString_ThrowsArgumentNullException() 
+{
+    // Arrange.
+    string str = null;
+
+    // Assert.
+    Regex r = new Regex(null);
+
+   // Act.
+}
+}",
+"Regex_UsingNullString_ThrowsArgumentNullException",
+5,
+13,
+TestSettingsData.NUnitSettings,
+false,
+true
+            };
+
+            // A test method has the ArrangeActAssert comments in the wrong order.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class RegexUnitTests
+{
+[Test]
+public void Regex_UsingNullString_ThrowsArgumentNullException() 
+{
+    // Act.
+    string str = null;
+
+    // Arrange.
+    Regex r = new Regex(null);
+
+   // Assert.
+}
+}",
+"Regex_UsingNullString_ThrowsArgumentNullException",
+5,
+13,
+TestSettingsData.NUnitSettings,
+false,
+false
+            };
+
+            // A test method has the ArrangeActAssert comments in the wrong order.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class RegexUnitTests
+{
+[Test]
+public void Regex_UsingNullString_ThrowsArgumentNullException() 
+{
+    // Act.
+    string str = null;
+
+    // Assert.
+    Regex r = new Regex(null);
+
+   // Arrange.
+}
+}",
+"Regex_UsingNullString_ThrowsArgumentNullException",
+5,
+13,
+TestSettingsData.NUnitSettings,
+false,
+false
+            };
+
+            // A test method has the ArrangeActAssert comments in the wrong order.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class RegexUnitTests
+{
+[Test]
+public void Regex_UsingNullString_ThrowsArgumentNullException() 
+{
+    // Assert.
+    string str = null;
+
+    // Act.
+    Regex r = new Regex(null);
+
+   // Arrange.
+}
+}",
+"Regex_UsingNullString_ThrowsArgumentNullException",
+5,
+13,
+TestSettingsData.NUnitSettings,
+false,
+false
+            };
+
+            // A test method has the ArrangeActAssert comments in the wrong order.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class RegexUnitTests
+{
+[Test]
+public void Regex_UsingNullString_ThrowsArgumentNullException() 
+{
+    // Assert.
+    string str = null;
+
+    // Arrange.
+    Regex r = new Regex(null);
+
+   // Act.
+}
+}",
+"Regex_UsingNullString_ThrowsArgumentNullException",
+5,
+13,
+TestSettingsData.NUnitSettings,
+false,
+false
+            };
+
+            // A test method does not have the // Arrange. comment as the first line of its body.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class RegexUnitTests
+{
+[Test]
+public void Regex_UsingNullString_ThrowsArgumentNullException() 
+{
+
+    // Arrange.
+    string str = null;
+
+    // Act.
+    Regex r = new Regex(null);
+
+   // Assert.
+}
+}",
+"Regex_UsingNullString_ThrowsArgumentNullException",
+5,
+13,
+TestSettingsData.NUnitSettings,
+true,
+false
+            };
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+    }
+}

--- a/UnitTestAnalyzers/UnitTestAnalyzers.Test/TestData/UseAAACommentsAnalyzerNUnitTestValidData.cs
+++ b/UnitTestAnalyzers/UnitTestAnalyzers.Test/TestData/UseAAACommentsAnalyzerNUnitTestValidData.cs
@@ -1,0 +1,69 @@
+﻿namespace UnitTestAnalyzers.Test.TestData
+{
+    using System.Collections;
+    using System.Collections.Generic;
+
+    internal class UseAAACommentsAnalyzerNUnitTestValidData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            // A test method with empty body.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class RegexUnitTests
+{
+[Test]
+public void Regex_UsingNullString_ThrowsArgumentNullException() 
+{
+}
+}",
+TestSettingsData.NUnitSettings
+            };
+
+            // A test method that does not invoke a member or constructor.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class RegexUnitTests
+{
+[Test]
+public void Regex_UsingNullString_ThrowsArgumentNullException() 
+{
+     string foo = ""foo"";
+}
+}",
+TestSettingsData.NUnitSettings
+            };
+
+            // A test method with the // Arrange. // Act. // Assert. comments.
+            // Each AAA comment appears only once and in the expected order.
+            // The first line of the test body is // Arrange.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class RegexUnitTests
+{
+[Test]
+public void Split_UsingSplitableString_ExpectsStringIsSplit() 
+{
+   // Arrange.
+   string foo = ""foo foo"";
+
+   // Act.
+   var parts = foo.Split(' ')[0];
+
+   // Assert.
+   Assert.IsNotNull(parts);
+}
+}",
+TestSettingsData.NUnitSettings
+            };
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+    }
+}

--- a/UnitTestAnalyzers/UnitTestAnalyzers.Test/TestData/UseCorrectTestNameFormatNUnitTestInvalidData.cs
+++ b/UnitTestAnalyzers/UnitTestAnalyzers.Test/TestData/UseCorrectTestNameFormatNUnitTestInvalidData.cs
@@ -1,0 +1,209 @@
+﻿namespace UnitTestAnalyzers.Test.TestData
+{
+    using System.Collections;
+    using System.Collections.Generic;
+    using Settings.ObjectModel;
+
+    internal class UseCorrectTestNameFormatNUnitTestInvalidData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            // A NUnit Test attribute is present (using statement) and the method name does not have the expected format.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class ClassName
+{
+[Test]
+public void Test1() {}
+}",
+"Test1", // Diagnostic message paramater
+5,  // Violation line
+13,  // Violation column.
+TestSettingsData.NUnitTestSettingsSimpleRegex,
+TestSettingsData.TestMethodNameSimpleFormat,
+TestSettingsData.TestMethodNameFormatSimpleRegexExamples
+            };
+
+            // A NUnit TestCase attribute is present (using statement) and the method name does not have the expected format.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class ClassName
+{
+[TestCase]
+public void Test1() {}
+}",
+"Test1",
+5,
+13,
+TestSettingsData.NUnitTestSettingsSimpleRegex,
+TestSettingsData.TestMethodNameSimpleFormat,
+TestSettingsData.TestMethodNameFormatSimpleRegexExamples
+            };
+
+            // A NUnit Test attribute is present (fully qualified name) and the method name does not have the expected format.
+            yield return new object[]
+            {
+                @"
+class ClassName
+{
+[NUnit.Framework.Test]
+public void Test1() {}
+}",
+"Test1",
+5,
+13,
+TestSettingsData.NUnitTestSettingsSimpleRegex,
+TestSettingsData.TestMethodNameSimpleFormat,
+TestSettingsData.TestMethodNameFormatSimpleRegexExamples
+            };
+
+            // A NUnit.Framework TestCase attribute is present (fully qualified name) and the method name does not have the expected format.
+            yield return new object[]
+            {
+                @"
+class ClassName
+{
+[NUnit.Framework.TestCase]
+public void Test1() {}
+}",
+"Test1",
+5,
+13,
+TestSettingsData.NUnitTestSettingsSimpleRegex,
+TestSettingsData.TestMethodNameSimpleFormat,
+TestSettingsData.TestMethodNameFormatSimpleRegexExamples
+            };
+
+            // A NUNit Test attribute is grouped along with another attribute and the method name does not have the expected format.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class ClassNameTests
+{
+[MyAttribute, Test]
+public void Test1() {}
+}",
+"Test1",
+5,
+13,
+TestSettingsData.NUnitTestSettingsSimpleRegex,
+TestSettingsData.TestMethodNameSimpleFormat,
+TestSettingsData.TestMethodNameFormatSimpleRegexExamples
+            };
+
+            // A NUnit TestCase attribute is grouped along with another attribute and the method name does not have the expected format.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class ClassNameTests
+{
+[MyAttribute, TestCase]
+public void Test1() {}
+}",
+"Test1",
+5,
+13,
+TestSettingsData.NUnitTestSettingsSimpleRegex,
+TestSettingsData.TestMethodNameSimpleFormat,
+TestSettingsData.TestMethodNameFormatSimpleRegexExamples
+            };
+
+            // A NUnit Test attribute is present along with another attribute and the method name does not have the expected format.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class ClassNameTests
+{
+[MyAttribute]
+[Test]
+public void Test1() {}
+}",
+"Test1",
+6,
+13,
+TestSettingsData.NUnitTestSettingsSimpleRegex,
+TestSettingsData.TestMethodNameSimpleFormat,
+TestSettingsData.TestMethodNameFormatSimpleRegexExamples
+            };
+
+            // A NUNit TestCase attribute is present along with another attribute and the method name does not have the expected format.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class ClassNameTests
+{
+[MyAttribute]
+[TestCase]
+public void Test1() {}
+}",
+"Test1",
+6,
+13,
+TestSettingsData.NUnitTestSettingsSimpleRegex,
+TestSettingsData.TestMethodNameSimpleFormat,
+TestSettingsData.TestMethodNameFormatSimpleRegexExamples
+            };
+
+            // A NUnit Test attribute is present and the method name does not have the expected format.
+            //  A configuration settings is provided without a regex therefore the default regex should be used.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class ClassName
+{
+[Test]
+public void TestOne() {}
+}",
+"TestOne",
+5,
+13,
+TestSettingsData.NUnitSettings,
+AnalyzersSettings.DefaultFormat,
+AnalyzersSettings.TestMethodNameFormatDefaultRegexExamples
+            };
+
+            // A NUnit TestCase attribute is present and the method name does not have the expected format.
+            //  A configuration settings is provided without a regex therefore the default regex should be used.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class ClassName
+{
+[TestCase]
+public void TestOne() {}
+}",
+"TestOne",
+5,
+13,
+TestSettingsData.NUnitSettings,
+AnalyzersSettings.DefaultFormat,
+AnalyzersSettings.TestMethodNameFormatDefaultRegexExamples
+            };
+
+            // A NUnit TestCase attribute is present and the method name does not have the expected format.
+            //  A configuration settings is provided without format therefore the default format should be found in the message.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class ClassName
+{
+[TestCase]
+public void Test1() {}
+}",
+"Test1",
+5,
+13,
+TestSettingsData.NUnitTestSettingsSimpleRegexNoFormat,
+AnalyzersSettings.DefaultFormat,
+TestSettingsData.TestMethodNameFormatSimpleRegexExamples
+            };
+       }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+    }
+}

--- a/UnitTestAnalyzers/UnitTestAnalyzers.Test/TestData/UseCorrectTestNameFormatNUnitTestValidData.cs
+++ b/UnitTestAnalyzers/UnitTestAnalyzers.Test/TestData/UseCorrectTestNameFormatNUnitTestValidData.cs
@@ -1,0 +1,165 @@
+﻿namespace UnitTestAnalyzers.Test.TestData
+{
+    using System.Collections;
+    using System.Collections.Generic;
+
+    internal class UseCorrectTestNameFormatNUnitTestValidData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            // No method attribute is present.
+            yield return new object[]
+            {
+                @"
+class ClassName
+{
+public void Test1() {}
+}",
+TestSettingsData.NUnitTestSettingsSimpleRegex
+            };
+
+            // A random method attribute is present.
+            yield return new object[]
+            {
+                @"
+class ClassName
+{
+[MyAttribute]
+public void Test1() {}
+}",
+TestSettingsData.NUnitTestSettingsSimpleRegex
+            };
+
+            // A NUnit Test attribute is present (fully qualified name).
+            yield return new object[]
+            {
+                @"
+class ClassName
+{
+[UnitTestAnalyzers.Test.Attributes.Test]
+public void Test1() {}
+}",
+TestSettingsData.NUnitTestSettingsSimpleRegex
+            };
+
+            // A non-NUnit TestCase attribute is present (fully qualified name).
+            yield return new object[]
+            {
+                @"
+class ClassName
+{
+[UnitTestAnalyzers.Test.Attributes.TestCase]
+public void Test1() {}
+}",
+TestSettingsData.NUnitTestSettingsSimpleRegex
+            };
+
+            // A non-NUnit Test attribute is present (using statement).
+            yield return new object[]
+            {
+                @"using UnitTestAnalyzers.Test.Attributes;
+class ClassNameTests
+{
+[Test]
+public void Test1() {}
+}",
+TestSettingsData.NUnitTestSettingsSimpleRegex
+            };
+
+            // A non-NUnit TestCase attribute is present (using statement).
+            yield return new object[]
+            {
+                @"using UnitTestAnalyzers.Test.Attributes;
+class ClassNameTests
+{
+[TestCase]
+public void Test1() {}
+}",
+TestSettingsData.NUnitTestSettingsSimpleRegex
+            };
+
+            // A NUnit Test attribute is present (using statement) and the method name has the expected format.
+            // The provided settings does not contain a regex therefore the default format is enforced.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class ClassName
+{
+[Test]
+public void TestOne_UsingFoo_ThrowsResult() {}
+}",
+TestSettingsData.NUnitSettings
+            };
+
+            // A NUnit TestCase attribute is present (using statement) and the method name has the expected format.
+            // The provided settings does not contain a regex therefore the default format is enforced.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class ClassName
+{
+[TestCase]
+public void TestOne_UsingFoo_ThrowsResult() {}
+}",
+TestSettingsData.NUnitSettings
+            };
+
+            // A NUnit Test attribute is present (fully qualified named) and the method name has the expected format.
+            // The provided settings does not contain a regex therefore the default format is enforced.
+            yield return new object[]
+            {
+                @"
+class ClassName
+{
+[NUnit.Framework.Test]
+public void TestOne_WhenFoo_ExpectsResult() {}
+}",
+TestSettingsData.NUnitSettings
+            };
+
+            // A NUnit TestCase attribute is present (fully qualified named) and the method name has the expected format.
+            // The provided settings does not contain a regex therefore the default format is enforced.p
+            yield return new object[]
+            {
+                @"
+class ClassName
+{
+[NUnit.Framework.TestCase]
+public void TestOne_WhenFoo_ExpectsResult() {}
+}",
+TestSettingsData.NUnitSettings
+            };
+
+            // A NUnit Test attribute is present (using statement) and the method name has the expected format.
+            //  Additionally a settings is provided redefining the test name regex.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class ClassName
+{
+[Test]
+public void TestOne() {}
+}",
+TestSettingsData.NUnitTestSettingsSimpleRegex
+            };
+
+            // A NUnit TestCase attribute is present (using statement) and the method name has the expected format.
+            //  Additionally a settings is provided redefining the test name regex.
+            yield return new object[]
+            {
+                @"using using NUnit.Framework;
+class ClassName
+{
+[TestCase]
+public void TestOne() {}
+}",
+TestSettingsData.NUnitTestSettingsSimpleRegex
+            };
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+    }
+}

--- a/UnitTestAnalyzers/UnitTestAnalyzers.Test/TestData/UseCorrectTestNameFormatXunitTestValidData.cs
+++ b/UnitTestAnalyzers/UnitTestAnalyzers.Test/TestData/UseCorrectTestNameFormatXunitTestValidData.cs
@@ -134,10 +134,10 @@ TestSettingsData.XunitSettings
             //  Additionally a settings is provided redefining the test name regex.
             yield return new object[]
             {
-                @"using Microsoft.VisualStudio.TestTools.UnitTesting;
+                @"using Xunit;
 class ClassName
 {
-[TestMethod]
+[Fact]
 public void TestOne() {}
 }",
 TestSettingsData.XunitTestSettingsSimpleRegex
@@ -147,7 +147,7 @@ TestSettingsData.XunitTestSettingsSimpleRegex
             //  Additionally a settings is provided redefining the test name regex.
             yield return new object[]
             {
-                @"using Microsoft.VisualStudio.TestTools.UnitTesting;
+                @"using Xunit;
 class ClassName
 {
 [Theory]

--- a/UnitTestAnalyzers/UnitTestAnalyzers.Test/TestData/UseUnitTestsSuffixNUnitTestInvalidData.cs
+++ b/UnitTestAnalyzers/UnitTestAnalyzers.Test/TestData/UseUnitTestsSuffixNUnitTestInvalidData.cs
@@ -1,0 +1,172 @@
+﻿namespace UnitTestAnalyzers.Test.TestData
+{
+    using System.Collections;
+    using System.Collections.Generic;
+
+    internal class UseUnitTestsSuffixNUnitTestInvalidData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            // The class contains an NUnit Test method (using namespace) and the class name does not have the expected suffix.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class ClassName
+{
+[Test]
+public void TestMethod() {}
+}",
+"ClassName", // Diagnostic message parameter
+2,  // Violation line
+7,  // Violation column.
+TestSettingsData.NUnitSettings
+            };
+
+            // The class contains an NUnit TestCase method (using namespace) and the class name does not have the expected suffix.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class ClassName
+{
+[TestCase]
+public void TestMethod() {}
+}",
+"ClassName",
+2,
+7,
+TestSettingsData.NUnitSettings
+            };
+
+            // The class contains an NUnit Test method (fully qualified name) and the class name does not have the expected suffix.
+            yield return new object[]
+            {
+                @"
+class ClassName
+{
+[NUnit.Framework.Test]
+public void TestMethod() {}
+}",
+"ClassName",
+2,
+7,
+TestSettingsData.NUnitSettings
+            };
+
+            // The class contains an NUnit TestCase method (fully qualified name) and the class name does not have the expected suffix.
+            yield return new object[]
+            {
+                @"
+class ClassName
+{
+[NUnit.Framework.TestCase]
+public void TestMethod() {}
+}",
+"ClassName",
+2,
+7,
+TestSettingsData.NUnitSettings
+            };
+
+            // A Test attribute is grouped along with another attribute and the class name does not have the expected suffix.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class ClassNameFunctionalTests
+{
+[Test, MyAttribute]
+public void TestMethod() {}
+}",
+"ClassNameFunctionalTests",
+2,
+7,
+TestSettingsData.NUnitSettings
+            };
+
+            // A TestCase attribute is grouped along with another attribute and the class name does not have the expected suffix.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class ClassNameFunctionalTests
+{
+[TestCase, MyAttribute]
+public void TestMethod() {}
+}",
+"ClassNameFunctionalTests",
+2,
+7,
+TestSettingsData.NUnitSettings
+            };
+
+            // A Test attribute is present along with another attribute and the class name does not have the expected suffix.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class ClassNameFunctionalTests
+{
+[Test]
+[MyAttribute]
+public void TestMethod() {}
+}",
+"ClassNameFunctionalTests",
+2,
+7,
+TestSettingsData.NUnitSettings
+            };
+
+            // A TestCase attribute is present along with another attribute and the class name does not have the expected suffix.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class ClassNameFunctionalTests
+{
+[TestCase]
+[MyAttribute]
+public void TestMethod() {}
+}",
+"ClassNameFunctionalTests",
+2,
+7,
+TestSettingsData.NUnitSettings
+            };
+
+            // A class contains other method in addition to a Test method and the class name does not have the expected suffix.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class ClassNameFunctionalTests
+{
+public void AnotherMethod() {}
+[Test]
+public void TestMethod() {}
+}",
+"ClassNameFunctionalTests",
+2,
+7,
+TestSettingsData.NUnitSettings
+            };
+
+            // A class contains other method in addition to a TestCase method and the class name does not have the expected suffix.
+            yield return new object[]
+            {
+                @"using NUnit.Framework;
+class ClassNameFunctionalTests
+{
+[TestCase]
+[MyAttribute]
+public void TestMethod() {}
+
+public void AnotherMethod() {}
+}",
+"ClassNameFunctionalTests",
+2,
+7,
+TestSettingsData.NUnitSettings
+            };
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+    }
+}

--- a/UnitTestAnalyzers/UnitTestAnalyzers.Test/TestData/UseUnitTestsSuffixNUnitTestValidData.cs
+++ b/UnitTestAnalyzers/UnitTestAnalyzers.Test/TestData/UseUnitTestsSuffixNUnitTestValidData.cs
@@ -1,0 +1,114 @@
+﻿namespace UnitTestAnalyzers.Test.TestData
+{
+    using System.Collections;
+    using System.Collections.Generic;
+
+    internal class UseUnitTestsSuffixNUnitTestValidData : IEnumerable<string[]>
+    {
+        public IEnumerator<string[]> GetEnumerator()
+        {
+            // No method in class.
+            yield return new[] { @"class ClassName {}", TestSettingsData.NUnitSettings };
+
+            // No test method (Test or TestCase) in class. A method is present without any attribute.
+            yield return new[]
+            {
+                @"
+class ClassName
+{
+public void SomeMethod() {}
+}",
+TestSettingsData.NUnitSettings
+            };
+
+            // No test method (Test or TestCase) in class. A method is present without some attribute.
+            yield return new[]
+            {
+                @"
+class ClassName
+{
+[MyAttribute]
+public void SomeMethod() {}
+}",
+TestSettingsData.NUnitSettings
+            };
+
+            // A non-NUnit Test attribute present (fully qualified name).
+            yield return new[]
+            {
+                @"
+class ClassName
+{
+[UnitTestAnalyzers.Test.Attributes.Test]
+public void MyMethod() {}
+}",
+TestSettingsData.NUnitSettings
+            };
+
+            // A non-NUnit TestCase attribute present (fully qualified name).
+            yield return new[]
+            {
+                @"
+class ClassName
+{
+[UnitTestAnalyzers.Test.Attributes.TestCase]
+public void MyMethod() {}
+}",
+TestSettingsData.NUnitSettings
+            };
+
+            // A non-NUnit Test attribute present (using statement).
+            yield return new[]
+            {
+                @"using UnitTestAnalyzers.Test.Attributes;
+class ClassName
+{
+[Test]
+public void MyMethod() {}
+}",
+TestSettingsData.NUnitSettings
+            };
+
+            // A non-NUnit TestCase attribute present (using statement).
+            yield return new[]
+            {
+                @"using UnitTestAnalyzers.Test.Attributes;
+class ClassName
+{
+[TestCase]
+public void MyMethod() {}
+}",
+TestSettingsData.NUnitSettings
+            };
+
+            // A NUnit Test method is present (fully qualified name) and the class name has the expected suffix.
+            yield return new[]
+            {
+                @"
+class ClassNameUnitTests
+{
+[NUnit.Framework.Test]
+public void TestMethod() {}
+}",
+TestSettingsData.NUnitSettings
+            };
+
+            // A NUnit TestCase method is present (fully qualified name) and the class name has the expected suffix.
+            yield return new[]
+            {
+                @"
+class ClassNameUnitTests
+{
+[NUnit.Framework.TestCase]
+public void TestMethod() {}
+}",
+TestSettingsData.NUnitSettings
+            };
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+    }
+}

--- a/UnitTestAnalyzers/UnitTestAnalyzers.Test/UnitTestAnalyzers.FunctionalTests.csproj
+++ b/UnitTestAnalyzers/UnitTestAnalyzers.Test/UnitTestAnalyzers.FunctionalTests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\NUnit.3.11.0\build\NUnit.props" Condition="Exists('..\..\packages\NUnit.3.11.0\build\NUnit.props')" />
   <Import Project="..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <PropertyGroup>
@@ -15,6 +16,8 @@
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -70,6 +73,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Newtonsoft.Json.8.0.2\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="nunit.framework, Version=3.11.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.11.0\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Collections.Immutable.1.1.37\lib\dotnet\System.Collections.Immutable.dll</HintPath>
@@ -104,9 +110,7 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework">
-      <Private>false</Private>
-    </Reference>
+ <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System.Xml" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
@@ -129,23 +133,31 @@
     <Compile Include="Naming\UseUnitTestsSuffixFunctionalTests.cs" />
     <Compile Include="TestData\TestNameMustIncludeMemberUnderTestAnalyzerMSTestInvalidData.cs" />
     <Compile Include="TestData\TestNameMustIncludeMemberUnderTestAnalyzerMSTestValidData.cs" />
+    <Compile Include="TestData\TestNameMustIncludeMemberUnderTestAnalyzerNUnitTestInvalidData.cs" />
     <Compile Include="TestData\TestNameMustIncludeMemberUnderTestAnalyzerXunitTestInvalidData.cs" />
+    <Compile Include="TestData\TestNameMustIncludeMemberUnderTestAnalyzerNUnitTestValidData.cs" />
     <Compile Include="TestData\TestNameMustIncludeMemberUnderTestAnalyzerXunitTestValidData.cs" />
     <Compile Include="TestData\TestSettingsData.cs" />
     <Compile Include="TestData\UseAAACommentsAnalyzerMSTestInvalidData.cs" />
     <Compile Include="TestData\UseAAACommentsAnalyzerMSTestValidData.cs" />
+    <Compile Include="TestData\UseAAACommentsAnalyzerNUnitTestInvalidData.cs" />
     <Compile Include="TestData\UseAAACommentsAnalyzerXunitTestInvalidData.cs" />
+    <Compile Include="TestData\UseAAACommentsAnalyzerNUnitTestValidData.cs" />
     <Compile Include="TestData\UseAAACommentsAnalyzerXunitTestValidData.cs" />
     <Compile Include="TestData\UseCorrectTestNameFormatMSTestInvalidData.cs" />
     <Compile Include="TestData\UseCorrectTestNameFormatMSTestValidData.cs" />
+    <Compile Include="TestData\UseCorrectTestNameFormatNUnitTestInvalidData.cs" />
     <Compile Include="TestData\UseCorrectTestNameFormatXunitTestInvalidData.cs" />
+    <Compile Include="TestData\UseCorrectTestNameFormatNUnitTestValidData.cs" />
     <Compile Include="TestData\UseCorrectTestNameFormatXunitTestValidData.cs" />
     <Compile Include="TestData\UseUnitTestsSuffixMSTestInvalidData.cs" />
     <Compile Include="TestData\UseUnitTestsSuffixMSTestValidData.cs" />
     <Compile Include="Helpers\DiagnosticResult.cs" />
     <Compile Include="Helpers\DiagnosticVerifier.Helper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestData\UseUnitTestsSuffixNUnitTestInvalidData.cs" />
     <Compile Include="TestData\UseUnitTestsSuffixXunitTestInvalidData.cs" />
+    <Compile Include="TestData\UseUnitTestsSuffixNUnitTestValidData.cs" />
     <Compile Include="TestData\UseUnitTestsSuffixXunitTestValidData.cs" />
     <Compile Include="Verifiers\DiagnosticVerifier.cs" />
   </ItemGroup>
@@ -180,6 +192,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props'))" />
     <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\..\packages\NUnit.3.11.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NUnit.3.11.0\build\NUnit.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/UnitTestAnalyzers/UnitTestAnalyzers.Test/packages.config
+++ b/UnitTestAnalyzers/UnitTestAnalyzers.Test/packages.config
@@ -9,6 +9,7 @@
   <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.1" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.1" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
+  <package id="NUnit" version="3.11.0" targetFramework="net452" />
   <package id="StyleCop.Analyzers" version="1.0.0" targetFramework="net452" developmentDependency="true" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />

--- a/UnitTestAnalyzers/UnitTestAnalyzers/Design/TestNameMustIncludeMemberUnderTestAnalyzer.cs
+++ b/UnitTestAnalyzers/UnitTestAnalyzers/Design/TestNameMustIncludeMemberUnderTestAnalyzer.cs
@@ -45,23 +45,7 @@
         private static void HandleCompilationStart(CompilationStartAnalysisContext context)
         {
             AnalyzersSettings settings = SettingsProvider.GetSettings(context);
-
-            IUnitTestParser unitTestParser;
-
-            switch (settings.UnitTestFramework)
-            {
-                    case UnitTestFramework.MSTest:
-                    unitTestParser = new MSTestParser();
-                    break;
-
-                    case UnitTestFramework.Xunit:
-                    unitTestParser = new XunitTestParser();
-                    break;
-
-                default:
-                    throw new NotSupportedException();
-            }
-
+            var unitTestParser = UnitTestParserFactory.Create(settings);
             context.RegisterSyntaxNodeAction(c => AnalyzeNode(c, unitTestParser, settings), SyntaxKind.MethodDeclaration);
         }
 

--- a/UnitTestAnalyzers/UnitTestAnalyzers/Documentation/UseAAACommentsAnalyzer.cs
+++ b/UnitTestAnalyzers/UnitTestAnalyzers/Documentation/UseAAACommentsAnalyzer.cs
@@ -57,23 +57,7 @@
         private static void HandleCompilationStart(CompilationStartAnalysisContext context)
         {
             AnalyzersSettings settings = SettingsProvider.GetSettings(context);
-
-            IUnitTestParser unitTestParser;
-
-            switch (settings.UnitTestFramework)
-            {
-                    case UnitTestFramework.MSTest:
-                    unitTestParser = new MSTestParser();
-                    break;
-
-                    case UnitTestFramework.Xunit:
-                    unitTestParser = new XunitTestParser();
-                    break;
-
-                default:
-                    throw new NotSupportedException();
-            }
-
+            var unitTestParser = UnitTestParserFactory.Create(settings);
             context.RegisterSyntaxNodeAction(c => AnalyzeNode(c, unitTestParser), SyntaxKind.MethodDeclaration);
         }
 

--- a/UnitTestAnalyzers/UnitTestAnalyzers/Naming/UseCorrectTestNameFormatAnalyzer.cs
+++ b/UnitTestAnalyzers/UnitTestAnalyzers/Naming/UseCorrectTestNameFormatAnalyzer.cs
@@ -42,22 +42,7 @@
         private static void HandleCompilationStart(CompilationStartAnalysisContext context)
         {
             AnalyzersSettings settings = SettingsProvider.GetSettings(context);
-            IUnitTestParser unitTestParser;
-
-            switch (settings.UnitTestFramework)
-            {
-                    case UnitTestFramework.MSTest:
-                    unitTestParser = new MSTestParser();
-                    break;
-
-                    case UnitTestFramework.Xunit:
-                    unitTestParser = new XunitTestParser();
-                    break;
-
-                default:
-                    throw new NotSupportedException();
-            }
-
+            IUnitTestParser unitTestParser = UnitTestParserFactory.Create(settings);
             context.RegisterSyntaxNodeAction(c => AnalyzeNode(c, unitTestParser, settings), SyntaxKind.MethodDeclaration);
         }
 

--- a/UnitTestAnalyzers/UnitTestAnalyzers/Naming/UseUnitTestsSuffixAnalyzer.cs
+++ b/UnitTestAnalyzers/UnitTestAnalyzers/Naming/UseUnitTestsSuffixAnalyzer.cs
@@ -41,22 +41,7 @@ namespace UnitTestAnalyzers
         private static void HandleCompilationStart(CompilationStartAnalysisContext context)
         {
             AnalyzersSettings settings = SettingsProvider.GetSettings(context);
-            IUnitTestParser unitTestParser;
-
-            switch (settings.UnitTestFramework)
-            {
-                case UnitTestFramework.MSTest:
-                    unitTestParser = new MSTestParser();
-                    break;
-
-                case UnitTestFramework.Xunit:
-                    unitTestParser = new XunitTestParser();
-                    break;
-
-                default:
-                    throw new NotSupportedException();
-            }
-
+            IUnitTestParser unitTestParser = UnitTestParserFactory.Create(settings);
             context.RegisterSyntaxNodeAction(c => AnalyzeNode(c, unitTestParser), SyntaxKind.ClassDeclaration);
         }
 

--- a/UnitTestAnalyzers/UnitTestAnalyzers/Parsers/AttributeBasedTestParser.cs
+++ b/UnitTestAnalyzers/UnitTestAnalyzers/Parsers/AttributeBasedTestParser.cs
@@ -1,0 +1,75 @@
+﻿namespace UnitTestAnalyzers.Parsers
+{
+    using System;
+    using System.Linq;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+
+    /// <summary>
+    /// A base class for test parser based on method attributes
+    /// </summary>
+    internal abstract class AttributeBasedTestParser : IUnitTestParser
+    {
+        /// <summary>
+        ///  Return the list of attributes full name used to mark test methods
+        /// </summary>
+        protected abstract string[] TestMethodAttributes { get; }
+
+        /// <inheritdoc />
+        public virtual bool IsUnitTestClass(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is ClassDeclarationSyntax classDeclaration)
+            {
+                var methods = classDeclaration.Members.OfType<MethodDeclarationSyntax>();
+                return methods.Any(x => this.IsUnitTestMethod(context, x));
+            }
+            return false;
+        }
+
+        /// <inheritdoc />
+        public bool IsUnitTestMethod(SyntaxNodeAnalysisContext context)
+        {
+            return this.IsUnitTestMethod(context, context.Node as MethodDeclarationSyntax);
+        }
+
+        private bool IsUnitTestMethod(SyntaxNodeAnalysisContext context, MethodDeclarationSyntax methodDeclaration)
+        {
+            var methodAttributes = methodDeclaration?.AttributeLists.SelectMany(a => a.Attributes).ToList();
+
+            if (!methodAttributes?.Any() ?? true)
+            {
+                return false;
+            }
+
+            if (methodAttributes.Any(methodAttribute => this.IsTestMethodAttribute(context, methodAttribute)))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool IsTestMethodAttribute(SyntaxNodeAnalysisContext context, AttributeSyntax attribute)
+        {
+            var attributeName = attribute.Name.ToString();
+
+            if (this.TestMethodAttributes.Any(x => x.EndsWith(attributeName, StringComparison.Ordinal) || x.EndsWith(attributeName + "Attribute", StringComparison.Ordinal)) == false)
+            {
+                return false;
+            }
+
+            var attributeSymbol = context.SemanticModel.GetSymbolInfo(attribute).Symbol as IMethodSymbol;
+
+            var attributeSymbolName = attributeSymbol?.ToString();
+
+            if (string.IsNullOrWhiteSpace(attributeSymbolName))
+            {
+                return false;
+            }
+
+
+            return this.TestMethodAttributes.Any(x => attributeSymbolName.StartsWith(x, StringComparison.Ordinal));
+        }
+    }
+}

--- a/UnitTestAnalyzers/UnitTestAnalyzers/Parsers/MSTestParser.cs
+++ b/UnitTestAnalyzers/UnitTestAnalyzers/Parsers/MSTestParser.cs
@@ -12,10 +12,15 @@
     /// presence of MSTest attributes.
     /// </summary>
     /// <seealso cref="UnitTestAnalyzers.Parsers.IUnitTestParser" />
-    internal class MSTestParser : IUnitTestParser
+    internal class MSTestParser : AttributeBasedTestParser
     {
+        /// <inheritdoc/>
+        protected override string[] TestMethodAttributes { get; } = {
+            "Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute"
+        };
+
         /// <inheritdoc />
-        public bool IsUnitTestClass(SyntaxNodeAnalysisContext context)
+        public override bool IsUnitTestClass(SyntaxNodeAnalysisContext context)
         {
             ClassDeclarationSyntax classDeclaration = context.Node as ClassDeclarationSyntax;
 
@@ -36,30 +41,6 @@
             var attributeSymbol = context.SemanticModel.GetSymbolInfo(testClassAttribute).Symbol as IMethodSymbol;
 
             return attributeSymbol?.ToString().StartsWith("Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute", StringComparison.Ordinal) ?? false;
-        }
-
-        /// <inheritdoc />
-        public bool IsUnitTestMethod(SyntaxNodeAnalysisContext context)
-        {
-            MethodDeclarationSyntax methodDeclaration = context.Node as MethodDeclarationSyntax;
-
-            IEnumerable<AttributeSyntax> attributes = methodDeclaration?.AttributeLists.SelectMany(x => x.Attributes).ToList();
-
-            if (!attributes?.Any() ?? true)
-            {
-                return false;
-            }
-
-            AttributeSyntax testMethodAttribute = attributes.FirstOrDefault(x => x.Name.ToString().EndsWith("TestMethod", StringComparison.Ordinal));
-
-            if (testMethodAttribute == null)
-            {
-                return false;
-            }
-
-            var attributeSymbol = context.SemanticModel.GetSymbolInfo(testMethodAttribute).Symbol as IMethodSymbol;
-
-            return attributeSymbol?.ToString().StartsWith("Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute", StringComparison.Ordinal) ?? false;
         }
     }
 }

--- a/UnitTestAnalyzers/UnitTestAnalyzers/Parsers/NUnitTestParser.cs
+++ b/UnitTestAnalyzers/UnitTestAnalyzers/Parsers/NUnitTestParser.cs
@@ -1,0 +1,20 @@
+﻿namespace UnitTestAnalyzers.Parsers
+{
+    using System;
+    using Microsoft.CodeAnalysis.Diagnostics;
+
+    /// <summary>
+    /// Evaluates analysis contexts determining if it represents NUnit elements according to the
+    /// presence of NUnit attributes.
+    /// </summary>
+    internal class NUnitTestParser: AttributeBasedTestParser
+    {
+        /// <inheritdoc/>
+        protected override string[] TestMethodAttributes { get; } = new[]
+        {
+            "NUnit.Framework.TestAttribute",
+            "NUnit.Framework.TestCaseAttribute",
+            "NUnit.Framework.TestCaseSourceAttribute",
+        };
+    }
+}

--- a/UnitTestAnalyzers/UnitTestAnalyzers/Parsers/UnitTestParserFactory.cs
+++ b/UnitTestAnalyzers/UnitTestAnalyzers/Parsers/UnitTestParserFactory.cs
@@ -1,0 +1,23 @@
+﻿namespace UnitTestAnalyzers.Parsers
+{
+    using System;
+    using Settings.ObjectModel;
+
+    internal static class UnitTestParserFactory
+    {
+        public static IUnitTestParser Create(AnalyzersSettings settings)
+        {
+            switch (settings.UnitTestFramework)
+            {
+                case UnitTestFramework.MSTest:
+                    return new MSTestParser();
+                case UnitTestFramework.Xunit:
+                    return new XunitTestParser();
+                case UnitTestFramework.NUnit:
+                    return new NUnitTestParser();
+                default:
+                    throw new NotSupportedException();
+            }
+        }
+    }
+}

--- a/UnitTestAnalyzers/UnitTestAnalyzers/Parsers/XUnitTestParser.cs
+++ b/UnitTestAnalyzers/UnitTestAnalyzers/Parsers/XUnitTestParser.cs
@@ -1,72 +1,16 @@
 ﻿namespace UnitTestAnalyzers.Parsers
 {
-    using System;
-    using System.Linq;
-    using Microsoft.CodeAnalysis;
-    using Microsoft.CodeAnalysis.CSharp.Syntax;
-    using Microsoft.CodeAnalysis.Diagnostics;
-
     /// <summary>
     /// Evaluates analysis contexts determining if it represents Xunit elements according to the
     /// presence of Xunit attributes.
     /// </summary>
     /// <seealso cref="UnitTestAnalyzers.Parsers.IUnitTestParser" />
-    internal class XunitTestParser : IUnitTestParser
+    internal class XunitTestParser : AttributeBasedTestParser
     {
-        /// <inheritdoc />
-        public bool IsUnitTestClass(SyntaxNodeAnalysisContext context)
-        {
-            if (context.Node is ClassDeclarationSyntax classDeclaration)
-            {
-                var methods = classDeclaration.Members.OfType<MethodDeclarationSyntax>();
-                return methods.Any(x => IsUnitTestMethod(context, x));
-            }
-            return false;
-        }
-
-        /// <inheritdoc />
-        public bool IsUnitTestMethod(SyntaxNodeAnalysisContext context)
-        {
-            return IsUnitTestMethod(context, context.Node as MethodDeclarationSyntax);
-        }
-
-        private static bool IsUnitTestMethod(SyntaxNodeAnalysisContext context, MethodDeclarationSyntax methodDeclaration)
-        {
-            var methodAttributes = methodDeclaration?.AttributeLists.SelectMany(a => a.Attributes).ToList();
-
-            if (!methodAttributes?.Any() ?? true)
-            {
-                return false;
-            }
-
-            if (methodAttributes.Any(methodAttribute => IsTestMethodAttribute(context, methodAttribute)))
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        private static bool IsTestMethodAttribute(SyntaxNodeAnalysisContext context, AttributeSyntax attribute)
-        {
-            string attributeName = attribute.Name.ToString();
-            if (!attributeName.EndsWith("Fact", StringComparison.Ordinal) &&
-                !attributeName.EndsWith("Theory", StringComparison.Ordinal))
-            {
-                return false;
-            }
-
-            var attributeSymbol = context.SemanticModel.GetSymbolInfo(attribute).Symbol as IMethodSymbol;
-
-            var attributeSymbolName = attributeSymbol?.ToString();
-
-            if (string.IsNullOrWhiteSpace(attributeSymbolName))
-            {
-                return false;
-            }
-
-            return attributeSymbolName.StartsWith("Xunit.FactAttribute", StringComparison.Ordinal) ||
-                   attributeSymbolName.StartsWith("Xunit.TheoryAttribute", StringComparison.Ordinal);
-        }
+        /// <inheritdoc/>
+        protected override string[] TestMethodAttributes { get; } = {
+            "Xunit.FactAttribute",
+            "Xunit.TheoryAttribute"
+        };
     }
 }

--- a/UnitTestAnalyzers/UnitTestAnalyzers/Parsers/XUnitTestParser.cs
+++ b/UnitTestAnalyzers/UnitTestAnalyzers/Parsers/XUnitTestParser.cs
@@ -16,35 +16,22 @@
         /// <inheritdoc />
         public bool IsUnitTestClass(SyntaxNodeAnalysisContext context)
         {
-            ClassDeclarationSyntax classDeclaration = context.Node as ClassDeclarationSyntax;
-
-            var methods = classDeclaration?.Members.OfType<MethodDeclarationSyntax>();
-
-            if (!methods?.Any() ?? true)
+            if (context.Node is ClassDeclarationSyntax classDeclaration)
             {
-                return false;
+                var methods = classDeclaration.Members.OfType<MethodDeclarationSyntax>();
+                return methods.Any(x => IsUnitTestMethod(context, x));
             }
-
-            var methodAttributes = methods.SelectMany(m => m.AttributeLists)?.SelectMany(a => a.Attributes).ToList();
-
-            if (!methodAttributes?.Any() ?? false)
-            {
-                return false;
-            }
-
-            if (methodAttributes.Any(methodAttribute => IsTestMethodAttribute(context, methodAttribute)))
-            {
-                return true;
-            }
-
             return false;
         }
 
         /// <inheritdoc />
         public bool IsUnitTestMethod(SyntaxNodeAnalysisContext context)
         {
-            MethodDeclarationSyntax methodDeclaration = context.Node as MethodDeclarationSyntax;
+            return IsUnitTestMethod(context, context.Node as MethodDeclarationSyntax);
+        }
 
+        private static bool IsUnitTestMethod(SyntaxNodeAnalysisContext context, MethodDeclarationSyntax methodDeclaration)
+        {
             var methodAttributes = methodDeclaration?.AttributeLists.SelectMany(a => a.Attributes).ToList();
 
             if (!methodAttributes?.Any() ?? true)

--- a/UnitTestAnalyzers/UnitTestAnalyzers/Settings/ObjectModel/UnitTestFramework.cs
+++ b/UnitTestAnalyzers/UnitTestAnalyzers/Settings/ObjectModel/UnitTestFramework.cs
@@ -13,6 +13,11 @@
         /// <summary>
         /// The Xunit framework.
         /// </summary>
-        Xunit
+        Xunit,
+
+        /// <summary>
+        /// The NUnit framework
+        /// </summary>
+        NUnit
     }
 }

--- a/UnitTestAnalyzers/UnitTestAnalyzers/UnitTestAnalyzers.csproj
+++ b/UnitTestAnalyzers/UnitTestAnalyzers/UnitTestAnalyzers.csproj
@@ -38,6 +38,7 @@
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Naming\UseCorrectTestNameFormatAnalyzer.cs" />
     <Compile Include="Naming\UseUnitTestsSuffixAnalyzer.cs" />
+    <Compile Include="Parsers\AttributeBasedTestParser.cs" />
     <Compile Include="Parsers\IUnitTestParser.cs" />
     <Compile Include="Parsers\MSTestParser.cs" />
     <Compile Include="Parsers\XunitTestParser.cs" />

--- a/UnitTestAnalyzers/UnitTestAnalyzers/UnitTestAnalyzers.csproj
+++ b/UnitTestAnalyzers/UnitTestAnalyzers/UnitTestAnalyzers.csproj
@@ -41,6 +41,8 @@
     <Compile Include="Parsers\AttributeBasedTestParser.cs" />
     <Compile Include="Parsers\IUnitTestParser.cs" />
     <Compile Include="Parsers\MSTestParser.cs" />
+    <Compile Include="Parsers\NUnitTestParser.cs" />
+    <Compile Include="Parsers\UnitTestParserFactory.cs" />
     <Compile Include="Parsers\XunitTestParser.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Resources.Designer.cs">


### PR DESCRIPTION
Hi

This PR contains implementation of `NUnitTestParser` that allows to run all diagnostics against the NUnit tests. I've also reduced code redundancy by introducing ` UnitTestParserFactory` and `AttributeBasedTestParser` class that helps to create test parsers based on attributes.  

All changes are accompanied by complete set of test cases for NUnit.